### PR TITLE
Look for code in _GET or _POST explicitly.

### DIFF
--- a/src/API/Oauth2Client.php
+++ b/src/API/Oauth2Client.php
@@ -237,10 +237,11 @@ class Oauth2Client {
      * @return Boolean Whether it exchanged the code or not correctly
      */
     public function exchangeCode() {
-        if (!isset($_REQUEST['code'])) {
+        $code = $_GET['code'] ?: $_POST['code'];
+        if (!isset($code)) {
+            $this->debugInfo("No code found in _GET or _POST params.");
             return false;
         }
-        $code = $_REQUEST['code'];
 
         $this->debugInfo("Code: ".$code);
 


### PR DESCRIPTION
This change is for those using frameworks or PHP configurations that strip out _REQUEST params.